### PR TITLE
Convert log-show-hide-{$type} messages to logeventslist-{$type}-log

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,6 +25,7 @@
 	"viewprotect-read-indicator": "<b>Restricted to: $1</b>",
 
 	"log-name-viewprotect": "View protection",
+	"logeventslist-viewprotect-log": "View protection log",
 	"log-show-hide-viewprotect": "$1 view protection log",
 	"log-description-viewprotect": "When a page's read protection is changed",
 	"logentry-viewprotect-read": "$1 {{GENDER:$2|changed}} read permission $3 from the '$4' group to the '$5' group",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -21,6 +21,7 @@
 	"viewprotect-read-indicator": "<b>Restricted to: $1</b>",
 
 	"log-name-viewprotect": "Name of log page",
+	"logeventslist-viewprotect-log": "View protection log option label on [[Special:Log]]",
 	"log-show-hide-viewprotect": "Indicator to hide/show view protections",
 	"log-description-viewprotect": "Description of what this is",
 	"logentry-viewprotect-hide": "User who hid a page",


### PR DESCRIPTION
Keeping the old message so that the extension continues to work with
older versions of MediaWiki.

Follows-up on https://gerrit.wikimedia.org/r/c/mediawiki/core/+/428871.

Bug: https://phabricator.wikimedia.org/T199657